### PR TITLE
Extend character limit for deparsing within dt_map

### DIFF
--- a/R/purrr.R
+++ b/R/purrr.R
@@ -156,7 +156,7 @@ dt_map2_df <- dt_map2_dfr
 anon_x <- function(fn) {
   if (is_formula(fn)) {
     fn %>%
-      deparse() %>%
+      deparse(200L) %>%
       str_replace("^~", "function(.x)") %>%
       parse_expr() %>%
       eval()
@@ -168,7 +168,7 @@ anon_x <- function(fn) {
 anon_xy <- function(fn) {
   if (is_formula(fn)) {
     fn %>%
-      deparse() %>%
+      deparse(200L) %>%
       str_replace("^~", "function(.x,.y)") %>%
       parse_expr() %>%
       eval()


### PR DESCRIPTION
Functions (.f) within have been cut off/limited to 50 characters by a default parameter within deparse(). After 50 characters, deparse outputs multiple objects, which breaks anon_x and anon_xy

Extending this to the maximum specified in [deparse documentation](https://rdrr.io/r/base/deparse.html) to allow longer functions